### PR TITLE
fix(swiper): strange effect on looping

### DIFF
--- a/src/layouts/components/PortfolioSingle.astro
+++ b/src/layouts/components/PortfolioSingle.astro
@@ -69,7 +69,6 @@ if (Array.isArray(information)) {
               spaceBetween: 40,
               slidesPerView: 1,
               centeredSlides: true,
-              loopAdditionalSlides: 2,
               autoplay: {
                 delay: 4000,
                 disableOnInteraction: true,


### PR DESCRIPTION
Some slides are skipped in auto loop of the swiper in /portfolios/ because of wrong option value loopAdditionalSlides